### PR TITLE
Add OCDS records explorer web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
-# prueba
-Esto es una prueba
-segundo cambio
+# Explorador de licitaciones públicas (OCDS Perú)
+
+Esta aplicación web estática consulta la API pública de [Contrataciones Abiertas](https://contratacionesabiertas.oece.gob.pe/api/v1/records) para mostrar los procesos de contratación del Estado peruano publicados en formato OCDS.
+
+## Características
+
+- Consulta la API con paginación configurable (20, 50 o 100 registros por página).
+- Permite filtrar los resultados por código UNSPSC, departamento, entidad compradora y palabras clave en la descripción.
+- Presenta la información en una tabla con enlaces directos a los releases oficiales y datos relevantes como monto estimado, fechas y OCID.
+- Maneja errores de conexión mostrando mensajes claros al usuario.
+
+## Requisitos
+
+La página consume la API directamente desde el navegador, por lo que es recomendable ejecutarla desde un servidor local para evitar bloqueos por CORS.
+
+## Ejecución local
+
+1. Clona o descarga este repositorio.
+2. Abre una terminal en la carpeta del proyecto.
+3. Inicia un servidor HTTP simple, por ejemplo con Python:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+4. Visita [http://localhost:8000/index.html](http://localhost:8000/index.html) en tu navegador.
+
+## Uso
+
+1. Ajusta los filtros deseados en el formulario (código UNSPSC, departamento, entidad compradora y/o descripción).
+2. Haz clic en **Buscar** para consultar la API con los filtros actuales.
+3. Utiliza los botones de navegación para avanzar o retroceder entre páginas.
+4. Pulsa **Limpiar filtros** para restablecer el formulario y volver a la primera página.
+
+## Notas
+
+- La API es paginada; el sitio solicita una página a la vez y aplica los filtros en el cliente.
+- Si la API introduce parámetros de filtrado nativos en el futuro, se podrían incorporar fácilmente en `main.js`.
+- Ante errores de red o restricciones de acceso, la página mostrará un mensaje de aviso y permitirá reintentar la consulta.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Explorador de licitaciones públicas (OCDS Perú)</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <h1>Explorador de licitaciones públicas</h1>
+      <p class="subtitle">
+        Consulta la API pública OCDS del Estado peruano y filtra por código
+        UNSPSC, departamento, entidad compradora y descripción.
+      </p>
+    </header>
+
+    <main class="container">
+      <section class="card">
+        <form id="filters" class="filters" autocomplete="off">
+          <fieldset>
+            <legend>Filtros de búsqueda</legend>
+            <div class="grid">
+              <label class="field">
+                <span>Código UNSPSC</span>
+                <input
+                  type="text"
+                  id="unspsc"
+                  name="unspsc"
+                  placeholder="Ej: 25101507"
+                />
+              </label>
+              <label class="field">
+                <span>Departamento</span>
+                <input
+                  type="text"
+                  id="department"
+                  name="department"
+                  placeholder="Ej: Lima"
+                />
+              </label>
+              <label class="field">
+                <span>Entidad compradora</span>
+                <input
+                  type="text"
+                  id="buyer"
+                  name="buyer"
+                  placeholder="Ej: Ministerio de Salud"
+                />
+              </label>
+              <label class="field">
+                <span>Descripción</span>
+                <input
+                  type="text"
+                  id="description"
+                  name="description"
+                  placeholder="Palabras clave del proceso"
+                />
+              </label>
+              <label class="field">
+                <span>Resultados por página</span>
+                <select id="pageSize" name="pageSize">
+                  <option value="20">20</option>
+                  <option value="50" selected>50</option>
+                  <option value="100">100</option>
+                </select>
+              </label>
+            </div>
+            <div class="actions">
+              <button type="submit" class="primary">Buscar</button>
+              <button type="button" id="clearFilters">Limpiar filtros</button>
+            </div>
+          </fieldset>
+        </form>
+      </section>
+
+      <section class="card status-bar">
+        <div class="status-text" id="summary"></div>
+        <div class="status-text" id="status"></div>
+      </section>
+
+      <section class="card pagination" aria-live="polite">
+        <div class="pager">
+          <button type="button" id="prevPage" aria-label="Página anterior">
+            ◀
+          </button>
+          <div id="pageInfo" class="page-info">Página 1</div>
+          <button type="button" id="nextPage" aria-label="Página siguiente">
+            ▶
+          </button>
+        </div>
+      </section>
+
+      <section class="card results">
+        <div class="table-wrapper">
+          <table id="results" aria-live="polite">
+            <thead>
+              <tr>
+                <th>Título</th>
+                <th>Entidad</th>
+                <th>Departamento</th>
+                <th>UNSPSC</th>
+                <th>Monto estimado</th>
+                <th>Fechas</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>
+        Fuente de datos:
+        <a
+          href="https://contratacionesabiertas.oece.gob.pe/api/v1/records"
+          target="_blank"
+          rel="noopener noreferrer"
+          >API pública OCDS del Estado peruano</a
+        >.
+      </p>
+    </footer>
+
+    <script src="main.js" defer></script>
+  </body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,442 @@
+const API_URL = "https://contratacionesabiertas.oece.gob.pe/api/v1/records";
+
+const form = document.getElementById("filters");
+const unspscInput = document.getElementById("unspsc");
+const departmentInput = document.getElementById("department");
+const buyerInput = document.getElementById("buyer");
+const descriptionInput = document.getElementById("description");
+const pageSizeSelect = document.getElementById("pageSize");
+const resultsTableBody = document.querySelector("#results tbody");
+const statusText = document.getElementById("status");
+const summaryText = document.getElementById("summary");
+const pageInfo = document.getElementById("pageInfo");
+const prevButton = document.getElementById("prevPage");
+const nextButton = document.getElementById("nextPage");
+const clearFiltersButton = document.getElementById("clearFilters");
+
+let currentPage = 1;
+let pageSize = Number(pageSizeSelect.value) || 50;
+let ongoingFetch = null;
+
+function getFilters() {
+  return {
+    unspsc: unspscInput.value.trim(),
+    department: departmentInput.value.trim(),
+    buyer: buyerInput.value.trim(),
+    description: descriptionInput.value.trim(),
+  };
+}
+
+function formatCurrency(amount, currency) {
+  if (typeof amount !== "number" || Number.isNaN(amount)) {
+    return "No disponible";
+  }
+
+  const formatter = new Intl.NumberFormat("es-PE", {
+    style: "currency",
+    currency: currency || "PEN",
+    maximumFractionDigits: 2,
+  });
+
+  return formatter.format(amount);
+}
+
+function formatDate(isoDate) {
+  if (!isoDate) return "Sin fecha";
+  try {
+    return new Date(isoDate).toLocaleString("es-PE", {
+      year: "numeric",
+      month: "short",
+      day: "2-digit",
+    });
+  } catch (error) {
+    return isoDate;
+  }
+}
+
+function extractBuyerNames(compiledRelease = {}) {
+  const buyers = new Set();
+  const directBuyer = compiledRelease.buyer?.name;
+  if (directBuyer) buyers.add(directBuyer);
+
+  const tenderBuyer = compiledRelease.tender?.procuringEntity?.name;
+  if (tenderBuyer) buyers.add(tenderBuyer);
+
+  const parties = Array.isArray(compiledRelease.parties)
+    ? compiledRelease.parties
+    : [];
+
+  parties.forEach((party) => {
+    const roles = Array.isArray(party.roles) ? party.roles : [];
+    if (roles.includes("buyer") || roles.includes("procuringEntity")) {
+      if (party.name) buyers.add(party.name);
+    }
+  });
+
+  return Array.from(buyers);
+}
+
+function extractDepartments(compiledRelease = {}) {
+  const departments = new Set();
+  const parties = Array.isArray(compiledRelease.parties)
+    ? compiledRelease.parties
+    : [];
+
+  parties.forEach((party) => {
+    const address = party.address || {};
+    const department = address.department || address.region;
+    if (department) {
+      departments.add(department);
+    }
+  });
+
+  return Array.from(departments);
+}
+
+function extractUnspscCodes(items = []) {
+  const badges = new Set();
+
+  items.forEach((item) => {
+    const { classification, additionalClassifications } = item || {};
+    const classifications = [];
+
+    if (classification) classifications.push(classification);
+    if (Array.isArray(additionalClassifications)) {
+      classifications.push(...additionalClassifications);
+    }
+
+    classifications.forEach((code) => {
+      if (!code) return;
+      const scheme = (code.scheme || "").toLowerCase();
+      const isUnspsc = scheme === "unspsc" || scheme === "unpsc";
+      if (!isUnspsc) return;
+
+      const id = String(code.id || "").trim();
+      const description = String(code.description || "").trim();
+      const label = description ? `${id} – ${description}` : id;
+      if (label) badges.add(label);
+    });
+  });
+
+  return Array.from(badges);
+}
+
+function extractItems(compiledRelease = {}) {
+  const tenderItems = compiledRelease.tender?.items;
+  if (!Array.isArray(tenderItems)) {
+    return [];
+  }
+  return tenderItems;
+}
+
+function applyFilters(records, filters) {
+  const unspscQuery = filters.unspsc.toLowerCase();
+  const departmentQuery = filters.department.toLowerCase();
+  const buyerQuery = filters.buyer.toLowerCase();
+  const descriptionQuery = filters.description.toLowerCase();
+
+  return records.filter((record) => {
+    const compiledRelease = record?.compiledRelease || {};
+    const tender = compiledRelease.tender || {};
+    const items = extractItems(compiledRelease);
+    const parties = Array.isArray(compiledRelease.parties)
+      ? compiledRelease.parties
+      : [];
+
+    const buyerNames = extractBuyerNames(compiledRelease);
+
+    const unspscMatches = unspscQuery
+      ? items.some((item) =>
+          extractUnspscCodes([item]).some((code) =>
+            code.toLowerCase().includes(unspscQuery)
+          )
+        )
+      : true;
+
+    const departmentMatches = departmentQuery
+      ? parties.some((party) => {
+          const address = party.address || {};
+          const combined = [
+            address.department,
+            address.region,
+            address.locality,
+          ]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase();
+          return combined.includes(departmentQuery);
+        })
+      : true;
+
+    const buyerMatches = buyerQuery
+      ? buyerNames.some((name) => name.toLowerCase().includes(buyerQuery))
+      : true;
+
+    const descriptionMatches = descriptionQuery
+      ? [
+          tender.title,
+          tender.description,
+          ...(items.map((item) => item?.description || "") || []),
+        ]
+          .filter(Boolean)
+          .some((text) => text.toLowerCase().includes(descriptionQuery))
+      : true;
+
+    return unspscMatches && departmentMatches && buyerMatches && descriptionMatches;
+  });
+}
+
+function clearTable() {
+  resultsTableBody.innerHTML = "";
+}
+
+function renderNoData(message) {
+  clearTable();
+  const row = document.createElement("tr");
+  const cell = document.createElement("td");
+  cell.colSpan = 6;
+  cell.textContent = message;
+  row.appendChild(cell);
+  resultsTableBody.appendChild(row);
+}
+
+function createList(items, className) {
+  if (!items.length) return null;
+  const container = document.createElement("div");
+  container.className = className;
+  items.forEach((item) => {
+    const badge = document.createElement("span");
+    badge.className = "badge";
+    badge.textContent = item;
+    container.appendChild(badge);
+  });
+  return container;
+}
+
+function renderRecords(records) {
+  clearTable();
+
+  if (!records.length) {
+    renderNoData("No hay resultados que coincidan con los filtros actuales.");
+    return;
+  }
+
+  records.forEach((record) => {
+    const compiledRelease = record?.compiledRelease || {};
+    const tender = compiledRelease.tender || {};
+    const row = document.createElement("tr");
+
+    const titleCell = document.createElement("td");
+    titleCell.className = "title-cell";
+
+    const link = document.createElement("a");
+    const detailUrl =
+      record?.releases?.[0]?.url || compiledRelease?.sources?.[0]?.url || "";
+    if (detailUrl) {
+      link.href = detailUrl;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+    }
+    link.textContent = tender.title || "Sin título";
+    titleCell.appendChild(link);
+
+    const ocid = compiledRelease.ocid || record.ocid;
+    if (ocid) {
+      const ocidMeta = document.createElement("div");
+      ocidMeta.className = "meta";
+      ocidMeta.textContent = ocid;
+      titleCell.appendChild(ocidMeta);
+    }
+
+    row.appendChild(titleCell);
+
+    const buyerCell = document.createElement("td");
+    const buyerNames = extractBuyerNames(compiledRelease);
+    buyerCell.textContent = buyerNames.join(", ") || "Sin información";
+    row.appendChild(buyerCell);
+
+    const departmentCell = document.createElement("td");
+    const departments = extractDepartments(compiledRelease);
+    departmentCell.textContent = departments.join(", ") || "No registrado";
+    row.appendChild(departmentCell);
+
+    const unspscCell = document.createElement("td");
+    const unspscCodes = extractUnspscCodes(extractItems(compiledRelease));
+    if (unspscCodes.length) {
+      const codesContainer = createList(unspscCodes, "unspsc-list");
+      unspscCell.appendChild(codesContainer);
+    } else {
+      unspscCell.textContent = "No especificado";
+    }
+    row.appendChild(unspscCell);
+
+    const amountCell = document.createElement("td");
+    const tenderValue = tender.value || {};
+    const amount = Number(tenderValue.amount);
+    const currency = tenderValue.currency || "PEN";
+    const amountText = formatCurrency(amount, currency);
+    const amountSpan = document.createElement("span");
+    amountSpan.className = "amount";
+    amountSpan.textContent = amountText;
+    amountCell.appendChild(amountSpan);
+    row.appendChild(amountCell);
+
+    const datesCell = document.createElement("td");
+    const published = formatDate(tender.datePublished || compiledRelease.date);
+    const updated = formatDate(compiledRelease.date);
+
+    const publishedRow = document.createElement("div");
+    const publishedLabel = document.createElement("strong");
+    publishedLabel.textContent = "Publicado:";
+    publishedRow.appendChild(publishedLabel);
+    publishedRow.appendChild(document.createTextNode(` ${published}`));
+
+    const updatedRow = document.createElement("div");
+    const updatedLabel = document.createElement("strong");
+    updatedLabel.textContent = "Actualizado:";
+    updatedRow.appendChild(updatedLabel);
+    updatedRow.appendChild(document.createTextNode(` ${updated}`));
+
+    datesCell.appendChild(publishedRow);
+    datesCell.appendChild(updatedRow);
+    row.appendChild(datesCell);
+
+    resultsTableBody.appendChild(row);
+  });
+}
+
+function updateSummary({
+  fetchedCount = 0,
+  filteredCount = 0,
+  totalRecords = null,
+  totalPages = null,
+} = {}) {
+  const parts = [];
+  parts.push(`Mostrando ${filteredCount} de ${fetchedCount} registros recibidos.`);
+
+  if (Number.isFinite(totalRecords)) {
+    parts.push(`Total reportado por la API: ${totalRecords}.`);
+  }
+
+  summaryText.textContent = parts.join(" ");
+
+  const pageParts = [`Página ${currentPage}`];
+  if (Number.isFinite(totalPages) && totalPages > 0) {
+    pageParts.push(`de ${totalPages}`);
+  }
+  pageInfo.textContent = pageParts.join(" ");
+}
+
+function setStatus(message = "") {
+  statusText.textContent = message;
+}
+
+function setLoading(isLoading) {
+  if (isLoading) {
+    setStatus("Cargando datos...");
+  } else if (statusText.textContent.startsWith("Cargando")) {
+    setStatus("");
+  }
+}
+
+async function fetchRecords(page) {
+  const params = new URLSearchParams({
+    page: String(page),
+    page_size: String(pageSize),
+    order: "desc",
+  });
+
+  const url = `${API_URL}?${params.toString()}`;
+
+  if (ongoingFetch) {
+    ongoingFetch.abort();
+  }
+
+  const controller = new AbortController();
+  ongoingFetch = controller;
+
+  const response = await fetch(url, { signal: controller.signal });
+  ongoingFetch = null;
+  if (!response.ok) {
+    throw new Error(`Error ${response.status} al consultar la API.`);
+  }
+  return response.json();
+}
+
+async function loadRecords(page = currentPage) {
+  const filters = getFilters();
+  setLoading(true);
+
+  try {
+    const data = await fetchRecords(page);
+    const records = Array.isArray(data.records) ? data.records : [];
+    const filteredRecords = applyFilters(records, filters);
+    renderRecords(filteredRecords);
+
+    const pagination = data.pagination || data.meta || {};
+    const totalRecords = Number(pagination.total ?? data.total);
+    const totalPages = Number(pagination.pages ?? pagination.total_pages);
+
+    currentPage = page;
+
+    updateSummary({
+      fetchedCount: records.length,
+      filteredCount: filteredRecords.length,
+      totalRecords: Number.isFinite(totalRecords) ? totalRecords : null,
+      totalPages: Number.isFinite(totalPages) ? totalPages : null,
+    });
+
+    const disablePrev = currentPage <= 1;
+    const disableNext =
+      (Number.isFinite(totalPages) && currentPage >= totalPages) ||
+      (!Number.isFinite(totalPages) && records.length < pageSize);
+
+    prevButton.disabled = disablePrev;
+    nextButton.disabled = disableNext;
+
+  } catch (error) {
+    if (error.name === "AbortError") {
+      return;
+    }
+
+    console.error(error);
+    renderNoData("No se pudieron obtener los datos de la API.");
+    setStatus(
+      "Ocurrió un error al consultar la API. Verifica tu conexión o intenta nuevamente."
+    );
+    updateSummary({ fetchedCount: 0, filteredCount: 0 });
+  } finally {
+    ongoingFetch = null;
+    setLoading(false);
+  }
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+  loadRecords(1);
+}
+
+function handleClear() {
+  form.reset();
+  pageSize = Number(pageSizeSelect.value) || 50;
+  loadRecords(1);
+}
+
+function handlePageChange(increment) {
+  const nextPage = Math.max(1, currentPage + increment);
+  if (nextPage === currentPage) return;
+  loadRecords(nextPage);
+}
+
+form.addEventListener("submit", handleSubmit);
+clearFiltersButton.addEventListener("click", handleClear);
+prevButton.addEventListener("click", () => handlePageChange(-1));
+nextButton.addEventListener("click", () => handlePageChange(1));
+pageSizeSelect.addEventListener("change", () => {
+  pageSize = Number(pageSizeSelect.value) || 50;
+  loadRecords(1);
+});
+
+document.addEventListener("DOMContentLoaded", () => {
+  loadRecords(1);
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,269 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  background-color: #f4f6fb;
+  color: #1f2a44;
+  line-height: 1.5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.site-header,
+.site-footer {
+  background: linear-gradient(120deg, #143d6d, #1060a4);
+  color: #fff;
+  padding: 1.5rem 1rem;
+  text-align: center;
+}
+
+.site-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.8rem, 2.5vw + 1rem, 2.6rem);
+}
+
+.site-header .subtitle {
+  margin: 0 auto;
+  max-width: 56rem;
+  font-size: 1rem;
+  opacity: 0.9;
+}
+
+.site-footer a {
+  color: #fff;
+  font-weight: 600;
+}
+
+.container {
+  width: min(1200px, 95vw);
+  margin: 2rem auto;
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background-color: #fff;
+  border-radius: 1rem;
+  box-shadow: 0 12px 30px rgba(23, 43, 77, 0.12);
+  padding: 1.5rem;
+}
+
+.filters fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.filters legend {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.filters .grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-weight: 600;
+  color: #0f1c2f;
+}
+
+.field input,
+.field select {
+  border-radius: 0.75rem;
+  border: 1px solid #d0d7e2;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field select:focus {
+  border-color: #0b74de;
+  box-shadow: 0 0 0 3px rgba(11, 116, 222, 0.2);
+  outline: none;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.7rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.actions .primary {
+  background: linear-gradient(120deg, #0c77e9, #00a0d6);
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(12, 119, 233, 0.25);
+}
+
+.actions button:not(.primary) {
+  background-color: #eef2f9;
+  color: #0f1c2f;
+}
+
+.actions button:hover {
+  transform: translateY(-1px);
+}
+
+.status-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.status-text {
+  min-height: 1.2rem;
+}
+
+.pagination .pager {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.pagination button {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: none;
+  background-color: #0c77e9;
+  color: #fff;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 18px rgba(12, 119, 233, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.pagination button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.pagination button:not(:disabled):hover {
+  transform: translateY(-1px);
+}
+
+.page-info {
+  font-weight: 600;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+thead {
+  background-color: #f0f4fb;
+  color: #0f1c2f;
+}
+
+thead th {
+  padding: 0.75rem;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+tbody tr:nth-child(even) {
+  background-color: rgba(15, 28, 47, 0.03);
+}
+
+th,
+td {
+  padding: 0.85rem;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(15, 28, 47, 0.05);
+}
+
+.title-cell {
+  font-weight: 700;
+  color: #0b3d91;
+}
+
+.title-cell a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.title-cell a:hover {
+  text-decoration: underline;
+}
+
+.meta,
+.unspsc-list {
+  margin: 0.3rem 0 0;
+  font-size: 0.85rem;
+  color: #47536b;
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  margin: 0.15rem 0.25rem 0.15rem 0;
+  border-radius: 999px;
+  background-color: rgba(12, 119, 233, 0.1);
+  color: #0c77e9;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.amount {
+  font-weight: 700;
+  color: #0f1c2f;
+}
+
+@media (max-width: 640px) {
+  .actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .pagination button {
+    width: 2.2rem;
+    height: 2.2rem;
+  }
+
+  th,
+  td {
+    padding: 0.7rem 0.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static HTML layout with filters for UNSPSC, departamento, entidad y descripción
- implement client-side logic to consultar la API de Contrataciones Abiertas, paginar y mostrar resultados filtrados
- style the interfaz con un diseño responsive y mensajes de estado claros

## Testing
- No automated tests were run (static web page)


------
https://chatgpt.com/codex/tasks/task_e_68ccb1774afc8333aa90e798c4213e7b