### PR TITLE
Create Procura landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,124 +2,546 @@
 <html lang="es">
   <head>
     <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Explorador de licitaciones públicas (OCDS Perú)</title>
+    <title>Automatiza tu carpeta de postulación para SEACE con IA + MCP | Procura</title>
+    <meta
+      name="description"
+      content="Genera declaraciones juradas, matriz de cumplimiento y oferta económica con IA. Cumplimiento trazable, firmas y empaquetado listo para SEACE."
+    />
+    <meta
+      name="keywords"
+      content="SEACE, OSCE, RNP, licitaciones públicas Perú, carpeta de postulación, bases integradas, matriz de cumplimiento, oferta económica, IA, MCP"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <header class="site-header">
-      <h1>Explorador de licitaciones públicas</h1>
-      <p class="subtitle">
-        Consulta la API pública OCDS del Estado peruano y filtra por código
-        UNSPSC, departamento, entidad compradora y descripción.
-      </p>
+    <header class="top-nav" id="top-nav">
+      <div class="container nav-content">
+        <a class="brand" href="#hero" aria-label="Procura inicio">Procura</a>
+        <nav class="nav-links" aria-label="Principal">
+          <button class="nav-toggle" aria-expanded="false" aria-controls="primary-menu">
+            <span class="sr-only">Mostrar u ocultar navegación</span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
+          <ul id="primary-menu">
+            <li><a href="#producto">Producto</a></li>
+            <li><a href="#como-funciona">Cómo funciona</a></li>
+            <li><a href="#seguridad">Seguridad</a></li>
+            <li><a href="#precios">Precios</a></li>
+            <li><a href="#preguntas">Preguntas</a></li>
+            <li><a href="#recursos">Recursos</a></li>
+          </ul>
+        </nav>
+        <div class="nav-ctas">
+          <a
+            class="btn ghost"
+            href="#lead-form"
+            data-analytics="cta-header-demo"
+            >Agendar demo</a
+          >
+          <a
+            class="btn primary"
+            href="#lead-form"
+            data-analytics="cta-header-free"
+            >Probar gratis</a
+          >
+        </div>
+      </div>
     </header>
 
-    <main class="container">
-      <section class="card">
-        <form id="filters" class="filters" autocomplete="off">
-          <fieldset>
-            <legend>Filtros de búsqueda</legend>
-            <div class="grid">
-              <label class="field">
-                <span>Código UNSPSC</span>
-                <input
-                  type="text"
-                  id="unspsc"
-                  name="unspsc"
-                  placeholder="Ej: 25101507"
-                />
-              </label>
-              <label class="field">
-                <span>Departamento</span>
-                <input
-                  type="text"
-                  id="department"
-                  name="department"
-                  placeholder="Ej: Lima"
-                />
-              </label>
-              <label class="field">
-                <span>Entidad compradora</span>
-                <input
-                  type="text"
-                  id="buyer"
-                  name="buyer"
-                  placeholder="Ej: Ministerio de Salud"
-                />
-              </label>
-              <label class="field">
-                <span>Descripción</span>
-                <input
-                  type="text"
-                  id="description"
-                  name="description"
-                  placeholder="Palabras clave del proceso"
-                />
-              </label>
-              <label class="field">
-                <span>Resultados por página</span>
-                <select id="pageSize" name="pageSize">
-                  <option value="20">20</option>
-                  <option value="50" selected>50</option>
-                  <option value="100">100</option>
-                </select>
-              </label>
+    <main>
+      <section class="hero" id="hero">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="tag">IA + MCP para licitaciones públicas</p>
+            <h1>Genera tu carpeta de postulación para SEACE en minutos con IA</h1>
+            <p class="lead">
+              Extrae requisitos de las Bases, completa datos variables y descarga tu paquete
+              listo para presentar. Con trazabilidad, firmas y control de cumplimiento.
+            </p>
+            <ul class="hero-bullets" role="list">
+              <li>Parser de Bases Integradas</li>
+              <li>Plantillas legales y técnicas</li>
+              <li>Oferta económica por ítem/paquete</li>
+              <li>Checklist y empaquetado</li>
+              <li>Firmas digitales/manuales</li>
+              <li>Auditoría y logs</li>
+            </ul>
+            <div class="hero-ctas">
+              <a class="btn primary" href="#lead-form" data-analytics="cta-hero-free"
+                >Probar gratis</a
+              >
+              <a class="btn secondary" href="#lead-form" data-analytics="cta-hero-demo"
+                >Agendar demo</a
+              >
             </div>
-            <div class="actions">
-              <button type="submit" class="primary">Buscar</button>
-              <button type="button" id="clearFilters">Limpiar filtros</button>
+            <p class="social-proof">
+              Cumple con art. 52 (contenidos mínimos) y buenas prácticas OSCE.
+              <span class="note">*Referencia informativa; no es asesoría legal.</span>
+            </p>
+          </div>
+          <div class="hero-media">
+            <figure class="workflow-illustration" aria-labelledby="workflow-title">
+              <figcaption id="workflow-title" class="sr-only">
+                Flujo simplificado: bases a parser, documentos, firma y entrega.
+              </figcaption>
+              <div class="workflow-steps">
+                <div class="step">Bases Integradas</div>
+                <div class="step">Parser IA</div>
+                <div class="step">Plantillas MCP</div>
+                <div class="step">Firma</div>
+                <div class="step">ZIP SEACE</div>
+              </div>
+            </figure>
+            <div class="mockups">
+              <div class="mockup" aria-hidden="true">
+                <span>Dashboard de procesos</span>
+              </div>
+              <div class="mockup" aria-hidden="true">
+                <span>Vista matriz de cumplimiento</span>
+              </div>
+              <div class="mockup" aria-hidden="true">
+                <span>Generador de oferta económica</span>
+              </div>
             </div>
-          </fieldset>
-        </form>
-      </section>
-
-      <section class="card status-bar">
-        <div class="status-text" id="summary"></div>
-        <div class="status-text" id="status"></div>
-      </section>
-
-      <section class="card pagination" aria-live="polite">
-        <div class="pager">
-          <button type="button" id="prevPage" aria-label="Página anterior">
-            ◀
-          </button>
-          <div id="pageInfo" class="page-info">Página 1</div>
-          <button type="button" id="nextPage" aria-label="Página siguiente">
-            ▶
-          </button>
+          </div>
         </div>
       </section>
 
-      <section class="card results">
-        <div class="table-wrapper">
-          <table id="results" aria-live="polite">
-            <thead>
-              <tr>
-                <th>Título</th>
-                <th>Entidad</th>
-                <th>Departamento</th>
-                <th>UNSPSC</th>
-                <th>Monto estimado</th>
-                <th>Fechas</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
+      <section class="section" id="producto">
+        <div class="container two-column">
+          <div>
+            <h2>Menos errores, más licitaciones presentadas a tiempo</h2>
+            <p>
+              Armar la carpeta de postulación consume horas: copiar formatos, revisar anexos,
+              cuadrar precios y firmar. Procura usa IA + MCP para estructurar la información y
+              guiarte paso a paso, dejando a tu equipo solo lo que requiere criterio comercial o
+              legal.
+            </p>
+          </div>
+          <div class="card highlight">
+            <h3>Ver demo guiada</h3>
+            <p>
+              Conoce el flujo completo en menos de 10 minutos y revisa un ejemplo real de
+              carpeta lista para cargar en SEACE.
+            </p>
+            <a class="btn secondary" href="#lead-form" data-analytics="cta-inline-demo"
+              >Ver demo guiada</a
+            >
+          </div>
+        </div>
+      </section>
+
+      <section class="section" id="como-funciona" aria-labelledby="steps-title">
+        <div class="container">
+          <h2 id="steps-title">Cómo funciona Procura</h2>
+          <div class="steps-grid">
+            <article class="step-card">
+              <span class="step-number">1</span>
+              <h3>Sube las Bases</h3>
+              <p>
+                Carga PDFs o Word. El parser extrae requisitos, anexos y EETT/TDR y construye la
+                matriz de cumplimiento automáticamente.
+              </p>
+            </article>
+            <article class="step-card">
+              <span class="step-number">2</span>
+              <h3>Completa variables</h3>
+              <p>
+                Un asistente guía precios finales, tiempos de entrega, garantías, consorcio y CVs
+                para cada proceso.
+              </p>
+            </article>
+            <article class="step-card">
+              <span class="step-number">3</span>
+              <h3>Genera documentos</h3>
+              <p>
+                Decl. juradas, aceptación de bases, matriz, oferta económica, carta de
+                presentación y promesa de consorcio en segundos.
+              </p>
+            </article>
+            <article class="step-card">
+              <span class="step-number">4</span>
+              <h3>Firma y empaqueta</h3>
+              <p>
+                Índice, foliado y ZIP listo para SEACE, con checklist de verificación y trazado de
+                responsabilidades.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section automation" aria-labelledby="automation-title">
+        <div class="container two-column">
+          <div>
+            <h2 id="automation-title">Qué automatizamos vs. qué completa tu equipo</h2>
+            <div class="columns">
+              <div>
+                <h3>Automatizamos</h3>
+                <ul>
+                  <li>Borradores de declaraciones juradas</li>
+                  <li>Matriz de cumplimiento actualizada</li>
+                  <li>Índice, rotulación y foliado</li>
+                  <li>Estructura de oferta económica con IGV</li>
+                  <li>Chequeos de vigencias y anexos</li>
+                </ul>
+              </div>
+              <div>
+                <h3>Completa tu equipo</h3>
+                <ul>
+                  <li>Precios finales y ajustes comerciales</li>
+                  <li>Marcas, modelos y fichas técnicas</li>
+                  <li>Tiempos de entrega y garantías</li>
+                  <li>Porcentajes y firmas de consorcio</li>
+                  <li>Documentos probatorios y certificados</li>
+                </ul>
+              </div>
+            </div>
+            <p class="disclaimer">
+              Tu organización conserva el control de la decisión comercial y la firma. Procura no
+              envía por ti en SEACE.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section features" aria-labelledby="features-title">
+        <div class="container">
+          <h2 id="features-title">Características claves</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Parser de Bases</h3>
+              <p>Extrae requisitos y anexos en minutos, con referencias a los folios originales.</p>
+            </article>
+            <article class="feature-card">
+              <h3>Plantillas legales y técnicas</h3>
+              <p>Modelos parametrizados y actualizables según la normativa OSCE vigente.</p>
+            </article>
+            <article class="feature-card">
+              <h3>Motor de precios</h3>
+              <p>Calcula ítem o paquete, IGV, redondeos y descuentos con alertas de coherencia.</p>
+            </article>
+            <article class="feature-card">
+              <h3>Validador de cumplimiento</h3>
+              <p>Rastrea cada requisito hacia el documento que lo respalda con evidencias.</p>
+            </article>
+            <article class="feature-card">
+              <h3>Firmas</h3>
+              <p>Flujos para firma manual o digital con certificados locales y control de versiones.</p>
+            </article>
+            <article class="feature-card">
+              <h3>Auditoría</h3>
+              <p>Logs de edición, aprobaciones y descargas listos para auditorías internas.</p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section technology" aria-labelledby="tech-title">
+        <div class="container two-column">
+          <div>
+            <h2 id="tech-title">Tecnología IA + MCP que escala contigo</h2>
+            <p>
+              MCP (Model Context Protocol) orquesta servidores para parsing, datos maestros,
+              render de documentos, firma y empaquetado. Mantén tus fuentes y permisos bajo
+              control, con auditoría completa y actualización continua.
+            </p>
+          </div>
+          <figure class="tech-diagram" aria-labelledby="diagram-title">
+            <figcaption id="diagram-title" class="sr-only">Diagrama del flujo MCP</figcaption>
+            <div class="diagram-flow">
+              <span>Bases</span>
+              <span>Parser</span>
+              <span>Plantillas</span>
+              <span>QA</span>
+              <span>Firma</span>
+              <span>ZIP</span>
+            </div>
+          </figure>
+        </div>
+      </section>
+
+      <section class="section security" id="seguridad" aria-labelledby="security-title">
+        <div class="container">
+          <h2 id="security-title">Seguridad y cumplimiento</h2>
+          <div class="security-grid">
+            <div class="security-item">Cifrado en reposo y en tránsito</div>
+            <div class="security-item">Separación de funciones (extracción ≠ firma)</div>
+            <div class="security-item">Control de accesos y roles</div>
+            <div class="security-item">Historial de cambios descargable</div>
+          </div>
+          <p class="disclaimer small">
+            Procura no brinda asesoría legal. Revisa tus Bases Integradas y normativa aplicable.
+          </p>
+        </div>
+      </section>
+
+      <section class="section integrations" aria-labelledby="integrations-title">
+        <div class="container">
+          <h2 id="integrations-title">Integraciones listas para conectar</h2>
+          <div class="chips">
+            <span class="chip">RNP (vigencia)</span>
+            <span class="chip">SEACE (asistencia de carga)</span>
+            <span class="chip">Correo corporativo</span>
+            <span class="chip">Drive / SharePoint</span>
+            <span class="chip">Firma digital (certificado local)</span>
+          </div>
+          <p class="note">Integraciones sujetas a configuración del cliente.</p>
+        </div>
+      </section>
+
+      <section class="section pricing" id="precios" aria-labelledby="pricing-title">
+        <div class="container">
+          <h2 id="pricing-title">Planes flexibles según tu volumen</h2>
+          <div class="pricing-grid">
+            <article class="plan-card">
+              <h3>Starter</h3>
+              <p class="tagline">Hasta 3 procesos/mes</p>
+              <p>Todo lo esencial para comenzar y validar el flujo.</p>
+              <a class="btn primary" href="#lead-form" data-analytics="cta-pricing-starter"
+                >Probar gratis</a
+              >
+            </article>
+            <article class="plan-card featured">
+              <h3>Pro</h3>
+              <p class="tagline">Hasta 15 procesos/mes</p>
+              <p>Automatización avanzada, validaciones y control de equipo.</p>
+              <a class="btn secondary" href="#lead-form" data-analytics="cta-pricing-pro"
+                >Hablar con ventas</a
+              >
+            </article>
+            <article class="plan-card">
+              <h3>Enterprise</h3>
+              <p class="tagline">Ilimitado</p>
+              <p>Flujos personalizados, SSO, auditoría, soporte y SLAs.</p>
+              <a class="btn ghost" href="#lead-form" data-analytics="cta-pricing-enterprise"
+                >Agendar demo</a
+              >
+            </article>
+          </div>
+          <p class="note">Precios en USD. Descuentos anuales disponibles.</p>
+        </div>
+      </section>
+
+      <section class="section testimonials" aria-labelledby="testimonials-title">
+        <div class="container">
+          <h2 id="testimonials-title">Resultados que hablan por sí solos</h2>
+          <div class="testimonial-grid">
+            <figure class="testimonial">
+              <blockquote>
+                “Reducimos 60% el tiempo de armado de carpeta y eliminamos reprocesos entre
+                logística y legal.”
+              </blockquote>
+              <figcaption>Gerente de Administración, proveedor industrial</figcaption>
+            </figure>
+            <figure class="testimonial">
+              <blockquote>
+                “Podemos postular simultáneamente a más procesos con el mismo equipo gracias al
+                checklist automatizado.”
+              </blockquote>
+              <figcaption>Jefa de Logística, servicios médicos</figcaption>
+            </figure>
+            <figure class="testimonial">
+              <blockquote>
+                “La trazabilidad requisito-documento nos permitió superar una auditoría interna sin
+                observaciones.”
+              </blockquote>
+              <figcaption>Director Comercial, tecnología educativa</figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      <section class="section faqs" id="preguntas" aria-labelledby="faq-title">
+        <div class="container">
+          <h2 id="faq-title">Preguntas frecuentes</h2>
+          <div class="faq-list">
+            <details>
+              <summary>¿Cumple con los contenidos mínimos?</summary>
+              <p>
+                Sí, generamos los borradores exigidos (declaraciones juradas, matriz de
+                cumplimiento, oferta económica, etc.) que debes revisar y firmar antes de enviar.
+              </p>
+            </details>
+            <details>
+              <summary>¿Pueden enviar la oferta en SEACE?</summary>
+              <p>
+                No automatizamos el envío. Te guiamos con un checklist y empaquetado listo para que
+                tu equipo lo cargue en SEACE.
+              </p>
+            </details>
+            <details>
+              <summary>¿Qué datos debo completar?</summary>
+              <p>
+                Precios, tiempos, composición de consorcio, documentos probatorios y la firma
+                responsable. El sistema valida que no falte nada.
+              </p>
+            </details>
+            <details>
+              <summary>¿Sirve para Adjudicación Simplificada/LP/SCI?</summary>
+              <p>
+                Sí, las plantillas son adaptables según las Bases y los formatos requeridos en cada
+                proceso.
+              </p>
+            </details>
+            <details>
+              <summary>¿Qué es MCP?</summary>
+              <p>
+                Es un estándar para conectar IA con herramientas y servidores de forma segura y
+                trazable, manteniendo tus datos bajo control.
+              </p>
+            </details>
+          </div>
+        </div>
+      </section>
+
+      <section class="section resources" id="recursos" aria-labelledby="resources-title">
+        <div class="container">
+          <h2 id="resources-title">Recursos para tu equipo</h2>
+          <div class="resource-grid">
+            <article class="resource-card">
+              <h3>Guía de checklist SEACE</h3>
+              <p>Descarga un checklist editable para asegurar el cumplimiento del art. 52.</p>
+              <a class="btn link" href="#lead-form" data-analytics="cta-resource-checklist"
+                >Solicitar recurso</a
+              >
+            </article>
+            <article class="resource-card">
+              <h3>Plantilla de matriz de riesgos</h3>
+              <p>Identifica riesgos comerciales y operativos antes de presentar tu oferta.</p>
+              <a class="btn link" href="#lead-form" data-analytics="cta-resource-risk"
+                >Descargar muestra</a
+              >
+            </article>
+            <article class="resource-card">
+              <h3>Workshop MCP para licitaciones</h3>
+              <p>Agenda una sesión para tu equipo y adapta los flujos a tus políticas internas.</p>
+              <a class="btn link" href="#lead-form" data-analytics="cta-resource-workshop"
+                >Reservar cupo</a
+              >
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section lead" id="lead-form" aria-labelledby="lead-title">
+        <div class="container lead-grid">
+          <div>
+            <h2 id="lead-title">Empieza hoy: genera tu primera carpeta con IA</h2>
+            <p>
+              Déjanos tus datos y recibe acceso a la prueba gratuita o coordina una demo con nuestro
+              equipo de especialistas en contrataciones públicas.
+            </p>
+            <div class="cta-buttons">
+              <a class="btn primary" href="#lead-form" data-analytics="cta-footer-free"
+                >Probar gratis</a
+              >
+              <a class="btn secondary" href="#lead-form" data-analytics="cta-footer-demo"
+                >Agendar demo</a
+              >
+            </div>
+          </div>
+          <form class="lead-form" aria-label="Formulario de contacto" novalidate>
+            <div class="form-grid">
+              <label>
+                Nombre
+                <input type="text" name="name" placeholder="Nombre completo" required />
+              </label>
+              <label>
+                Empresa
+                <input type="text" name="company" placeholder="Razón social" required />
+              </label>
+              <label>
+                RUC
+                <input type="text" name="ruc" placeholder="12345678901" pattern="\d{11}" />
+              </label>
+              <label>
+                Email
+                <input
+                  type="email"
+                  name="email"
+                  placeholder="nombre@empresa.com"
+                  required
+                  aria-required="true"
+                />
+              </label>
+              <label>
+                Teléfono
+                <input type="tel" name="phone" placeholder="+51 999 999 999" />
+              </label>
+              <label>
+                ¿Cuántas licitaciones al mes?
+                <select name="tenders">
+                  <option value="1-3">1-3</option>
+                  <option value="4-10">4-10</option>
+                  <option value="11-20">11-20</option>
+                  <option value="20+">Más de 20</option>
+                </select>
+              </label>
+              <label>
+                ¿Usas consorcios?
+                <select name="consortiums">
+                  <option value="si">Sí</option>
+                  <option value="no">No</option>
+                  <option value="planificando">Planificando</option>
+                </select>
+              </label>
+              <label class="full">
+                Mensaje
+                <textarea name="message" rows="3" placeholder="Cuéntanos qué buscas"></textarea>
+              </label>
+            </div>
+            <label class="consent">
+              <input type="checkbox" name="consent" required />
+              <span>Acepto la política de privacidad y recibir comunicaciones de Procura.</span>
+            </label>
+            <button class="btn primary" type="submit" data-analytics="cta-form-submit">
+              Enviar
+            </button>
+            <p class="form-success" role="status" aria-live="polite"></p>
+          </form>
         </div>
       </section>
     </main>
 
-    <footer class="site-footer">
-      <p>
-        Fuente de datos:
-        <a
-          href="https://contratacionesabiertas.oece.gob.pe/api/v1/records"
-          target="_blank"
-          rel="noopener noreferrer"
-          >API pública OCDS del Estado peruano</a
-        >.
-      </p>
+    <footer class="footer">
+      <div class="container footer-grid">
+        <a class="brand" href="#hero">Procura</a>
+        <div class="footer-ctas">
+          <a class="btn primary" href="#lead-form" data-analytics="cta-footer-free-bottom"
+            >Probar gratis</a
+          >
+          <a class="btn secondary" href="#lead-form" data-analytics="cta-footer-demo-bottom"
+            >Agendar demo</a
+          >
+        </div>
+        <nav aria-label="Enlaces del pie de página">
+          <ul>
+            <li><a href="#producto">Producto</a></li>
+            <li><a href="#como-funciona">Cómo funciona</a></li>
+            <li><a href="#seguridad">Seguridad</a></li>
+            <li><a href="#precios">Precios</a></li>
+            <li><a href="#preguntas">Preguntas</a></li>
+            <li><a href="#recursos">Recursos</a></li>
+          </ul>
+        </nav>
+        <div class="footer-links">
+          <a href="#">Términos</a>
+          <a href="#">Privacidad</a>
+          <a href="mailto:contacto@procura.com">Contacto</a>
+        </div>
+        <p class="copyright">© <span id="current-year"></span> Procura. Todos los derechos reservados.</p>
+      </div>
     </footer>
 
     <script src="main.js" defer></script>

--- a/main.js
+++ b/main.js
@@ -1,442 +1,103 @@
-const API_URL = "https://contratacionesabiertas.oece.gob.pe/api/v1/records";
+const navToggle = document.querySelector('.nav-toggle');
+const navLinks = document.querySelector('.nav-links');
+const menu = document.getElementById('primary-menu');
+const analyticsElements = document.querySelectorAll('[data-analytics]');
+const leadForm = document.querySelector('.lead-form');
+const successMessage = document.querySelector('.form-success');
+const yearTarget = document.getElementById('current-year');
 
-const form = document.getElementById("filters");
-const unspscInput = document.getElementById("unspsc");
-const departmentInput = document.getElementById("department");
-const buyerInput = document.getElementById("buyer");
-const descriptionInput = document.getElementById("description");
-const pageSizeSelect = document.getElementById("pageSize");
-const resultsTableBody = document.querySelector("#results tbody");
-const statusText = document.getElementById("status");
-const summaryText = document.getElementById("summary");
-const pageInfo = document.getElementById("pageInfo");
-const prevButton = document.getElementById("prevPage");
-const nextButton = document.getElementById("nextPage");
-const clearFiltersButton = document.getElementById("clearFilters");
-
-let currentPage = 1;
-let pageSize = Number(pageSizeSelect.value) || 50;
-let ongoingFetch = null;
-
-function getFilters() {
-  return {
-    unspsc: unspscInput.value.trim(),
-    department: departmentInput.value.trim(),
-    buyer: buyerInput.value.trim(),
-    description: descriptionInput.value.trim(),
-  };
-}
-
-function formatCurrency(amount, currency) {
-  if (typeof amount !== "number" || Number.isNaN(amount)) {
-    return "No disponible";
-  }
-
-  const formatter = new Intl.NumberFormat("es-PE", {
-    style: "currency",
-    currency: currency || "PEN",
-    maximumFractionDigits: 2,
-  });
-
-  return formatter.format(amount);
-}
-
-function formatDate(isoDate) {
-  if (!isoDate) return "Sin fecha";
-  try {
-    return new Date(isoDate).toLocaleString("es-PE", {
-      year: "numeric",
-      month: "short",
-      day: "2-digit",
-    });
-  } catch (error) {
-    return isoDate;
+function updateYear() {
+  if (yearTarget) {
+    yearTarget.textContent = new Date().getFullYear();
   }
 }
 
-function extractBuyerNames(compiledRelease = {}) {
-  const buyers = new Set();
-  const directBuyer = compiledRelease.buyer?.name;
-  if (directBuyer) buyers.add(directBuyer);
-
-  const tenderBuyer = compiledRelease.tender?.procuringEntity?.name;
-  if (tenderBuyer) buyers.add(tenderBuyer);
-
-  const parties = Array.isArray(compiledRelease.parties)
-    ? compiledRelease.parties
-    : [];
-
-  parties.forEach((party) => {
-    const roles = Array.isArray(party.roles) ? party.roles : [];
-    if (roles.includes("buyer") || roles.includes("procuringEntity")) {
-      if (party.name) buyers.add(party.name);
-    }
-  });
-
-  return Array.from(buyers);
-}
-
-function extractDepartments(compiledRelease = {}) {
-  const departments = new Set();
-  const parties = Array.isArray(compiledRelease.parties)
-    ? compiledRelease.parties
-    : [];
-
-  parties.forEach((party) => {
-    const address = party.address || {};
-    const department = address.department || address.region;
-    if (department) {
-      departments.add(department);
-    }
-  });
-
-  return Array.from(departments);
-}
-
-function extractUnspscCodes(items = []) {
-  const badges = new Set();
-
-  items.forEach((item) => {
-    const { classification, additionalClassifications } = item || {};
-    const classifications = [];
-
-    if (classification) classifications.push(classification);
-    if (Array.isArray(additionalClassifications)) {
-      classifications.push(...additionalClassifications);
-    }
-
-    classifications.forEach((code) => {
-      if (!code) return;
-      const scheme = (code.scheme || "").toLowerCase();
-      const isUnspsc = scheme === "unspsc" || scheme === "unpsc";
-      if (!isUnspsc) return;
-
-      const id = String(code.id || "").trim();
-      const description = String(code.description || "").trim();
-      const label = description ? `${id} – ${description}` : id;
-      if (label) badges.add(label);
-    });
-  });
-
-  return Array.from(badges);
-}
-
-function extractItems(compiledRelease = {}) {
-  const tenderItems = compiledRelease.tender?.items;
-  if (!Array.isArray(tenderItems)) {
-    return [];
+function toggleMenu() {
+  if (!navToggle || !navLinks) return;
+  const expanded = navToggle.getAttribute('aria-expanded') === 'true';
+  navToggle.setAttribute('aria-expanded', String(!expanded));
+  navLinks.classList.toggle('open', !expanded);
+  if (!expanded) {
+    menu?.querySelector('a')?.focus({ preventScroll: false });
   }
-  return tenderItems;
 }
 
-function applyFilters(records, filters) {
-  const unspscQuery = filters.unspsc.toLowerCase();
-  const departmentQuery = filters.department.toLowerCase();
-  const buyerQuery = filters.buyer.toLowerCase();
-  const descriptionQuery = filters.description.toLowerCase();
-
-  return records.filter((record) => {
-    const compiledRelease = record?.compiledRelease || {};
-    const tender = compiledRelease.tender || {};
-    const items = extractItems(compiledRelease);
-    const parties = Array.isArray(compiledRelease.parties)
-      ? compiledRelease.parties
-      : [];
-
-    const buyerNames = extractBuyerNames(compiledRelease);
-
-    const unspscMatches = unspscQuery
-      ? items.some((item) =>
-          extractUnspscCodes([item]).some((code) =>
-            code.toLowerCase().includes(unspscQuery)
-          )
-        )
-      : true;
-
-    const departmentMatches = departmentQuery
-      ? parties.some((party) => {
-          const address = party.address || {};
-          const combined = [
-            address.department,
-            address.region,
-            address.locality,
-          ]
-            .filter(Boolean)
-            .join(" ")
-            .toLowerCase();
-          return combined.includes(departmentQuery);
-        })
-      : true;
-
-    const buyerMatches = buyerQuery
-      ? buyerNames.some((name) => name.toLowerCase().includes(buyerQuery))
-      : true;
-
-    const descriptionMatches = descriptionQuery
-      ? [
-          tender.title,
-          tender.description,
-          ...(items.map((item) => item?.description || "") || []),
-        ]
-          .filter(Boolean)
-          .some((text) => text.toLowerCase().includes(descriptionQuery))
-      : true;
-
-    return unspscMatches && departmentMatches && buyerMatches && descriptionMatches;
-  });
+function closeMenuOnLinkClick(event) {
+  if (event.target instanceof HTMLElement && event.target.tagName === 'A') {
+    navToggle?.setAttribute('aria-expanded', 'false');
+    navLinks?.classList.remove('open');
+  }
 }
 
-function clearTable() {
-  resultsTableBody.innerHTML = "";
+function trackEvent(event) {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  const { analytics } = target.dataset;
+  if (!analytics) return;
+
+  window.dispatchEvent(
+    new CustomEvent('procura:analytics', {
+      detail: {
+        id: analytics,
+        timestamp: Date.now(),
+      },
+    })
+  );
+
+  if (window.console && typeof window.console.info === 'function') {
+    console.info(`[analytics] ${analytics}`);
+  }
 }
 
-function renderNoData(message) {
-  clearTable();
-  const row = document.createElement("tr");
-  const cell = document.createElement("td");
-  cell.colSpan = 6;
-  cell.textContent = message;
-  row.appendChild(cell);
-  resultsTableBody.appendChild(row);
-}
+function handleFormSubmit(event) {
+  event.preventDefault();
+  const form = event.currentTarget;
+  if (!(form instanceof HTMLFormElement)) return;
 
-function createList(items, className) {
-  if (!items.length) return null;
-  const container = document.createElement("div");
-  container.className = className;
-  items.forEach((item) => {
-    const badge = document.createElement("span");
-    badge.className = "badge";
-    badge.textContent = item;
-    container.appendChild(badge);
-  });
-  return container;
-}
-
-function renderRecords(records) {
-  clearTable();
-
-  if (!records.length) {
-    renderNoData("No hay resultados que coincidan con los filtros actuales.");
+  const formData = new FormData(form);
+  if (!formData.get('consent')) {
+    if (successMessage) {
+      successMessage.textContent = 'Debes aceptar la política de privacidad.';
+      successMessage.style.color = '#ff4d4f';
+    }
     return;
   }
 
-  records.forEach((record) => {
-    const compiledRelease = record?.compiledRelease || {};
-    const tender = compiledRelease.tender || {};
-    const row = document.createElement("tr");
-
-    const titleCell = document.createElement("td");
-    titleCell.className = "title-cell";
-
-    const link = document.createElement("a");
-    const detailUrl =
-      record?.releases?.[0]?.url || compiledRelease?.sources?.[0]?.url || "";
-    if (detailUrl) {
-      link.href = detailUrl;
-      link.target = "_blank";
-      link.rel = "noopener noreferrer";
-    }
-    link.textContent = tender.title || "Sin título";
-    titleCell.appendChild(link);
-
-    const ocid = compiledRelease.ocid || record.ocid;
-    if (ocid) {
-      const ocidMeta = document.createElement("div");
-      ocidMeta.className = "meta";
-      ocidMeta.textContent = ocid;
-      titleCell.appendChild(ocidMeta);
-    }
-
-    row.appendChild(titleCell);
-
-    const buyerCell = document.createElement("td");
-    const buyerNames = extractBuyerNames(compiledRelease);
-    buyerCell.textContent = buyerNames.join(", ") || "Sin información";
-    row.appendChild(buyerCell);
-
-    const departmentCell = document.createElement("td");
-    const departments = extractDepartments(compiledRelease);
-    departmentCell.textContent = departments.join(", ") || "No registrado";
-    row.appendChild(departmentCell);
-
-    const unspscCell = document.createElement("td");
-    const unspscCodes = extractUnspscCodes(extractItems(compiledRelease));
-    if (unspscCodes.length) {
-      const codesContainer = createList(unspscCodes, "unspsc-list");
-      unspscCell.appendChild(codesContainer);
-    } else {
-      unspscCell.textContent = "No especificado";
-    }
-    row.appendChild(unspscCell);
-
-    const amountCell = document.createElement("td");
-    const tenderValue = tender.value || {};
-    const amount = Number(tenderValue.amount);
-    const currency = tenderValue.currency || "PEN";
-    const amountText = formatCurrency(amount, currency);
-    const amountSpan = document.createElement("span");
-    amountSpan.className = "amount";
-    amountSpan.textContent = amountText;
-    amountCell.appendChild(amountSpan);
-    row.appendChild(amountCell);
-
-    const datesCell = document.createElement("td");
-    const published = formatDate(tender.datePublished || compiledRelease.date);
-    const updated = formatDate(compiledRelease.date);
-
-    const publishedRow = document.createElement("div");
-    const publishedLabel = document.createElement("strong");
-    publishedLabel.textContent = "Publicado:";
-    publishedRow.appendChild(publishedLabel);
-    publishedRow.appendChild(document.createTextNode(` ${published}`));
-
-    const updatedRow = document.createElement("div");
-    const updatedLabel = document.createElement("strong");
-    updatedLabel.textContent = "Actualizado:";
-    updatedRow.appendChild(updatedLabel);
-    updatedRow.appendChild(document.createTextNode(` ${updated}`));
-
-    datesCell.appendChild(publishedRow);
-    datesCell.appendChild(updatedRow);
-    row.appendChild(datesCell);
-
-    resultsTableBody.appendChild(row);
-  });
-}
-
-function updateSummary({
-  fetchedCount = 0,
-  filteredCount = 0,
-  totalRecords = null,
-  totalPages = null,
-} = {}) {
-  const parts = [];
-  parts.push(`Mostrando ${filteredCount} de ${fetchedCount} registros recibidos.`);
-
-  if (Number.isFinite(totalRecords)) {
-    parts.push(`Total reportado por la API: ${totalRecords}.`);
+  if (successMessage) {
+    successMessage.style.color = 'var(--color-accent)';
+    successMessage.textContent = '¡Gracias! Te escribiremos en menos de 24 horas con tu acceso.';
   }
-
-  summaryText.textContent = parts.join(" ");
-
-  const pageParts = [`Página ${currentPage}`];
-  if (Number.isFinite(totalPages) && totalPages > 0) {
-    pageParts.push(`de ${totalPages}`);
-  }
-  pageInfo.textContent = pageParts.join(" ");
-}
-
-function setStatus(message = "") {
-  statusText.textContent = message;
-}
-
-function setLoading(isLoading) {
-  if (isLoading) {
-    setStatus("Cargando datos...");
-  } else if (statusText.textContent.startsWith("Cargando")) {
-    setStatus("");
-  }
-}
-
-async function fetchRecords(page) {
-  const params = new URLSearchParams({
-    page: String(page),
-    page_size: String(pageSize),
-    order: "desc",
-  });
-
-  const url = `${API_URL}?${params.toString()}`;
-
-  if (ongoingFetch) {
-    ongoingFetch.abort();
-  }
-
-  const controller = new AbortController();
-  ongoingFetch = controller;
-
-  const response = await fetch(url, { signal: controller.signal });
-  ongoingFetch = null;
-  if (!response.ok) {
-    throw new Error(`Error ${response.status} al consultar la API.`);
-  }
-  return response.json();
-}
-
-async function loadRecords(page = currentPage) {
-  const filters = getFilters();
-  setLoading(true);
-
-  try {
-    const data = await fetchRecords(page);
-    const records = Array.isArray(data.records) ? data.records : [];
-    const filteredRecords = applyFilters(records, filters);
-    renderRecords(filteredRecords);
-
-    const pagination = data.pagination || data.meta || {};
-    const totalRecords = Number(pagination.total ?? data.total);
-    const totalPages = Number(pagination.pages ?? pagination.total_pages);
-
-    currentPage = page;
-
-    updateSummary({
-      fetchedCount: records.length,
-      filteredCount: filteredRecords.length,
-      totalRecords: Number.isFinite(totalRecords) ? totalRecords : null,
-      totalPages: Number.isFinite(totalPages) ? totalPages : null,
-    });
-
-    const disablePrev = currentPage <= 1;
-    const disableNext =
-      (Number.isFinite(totalPages) && currentPage >= totalPages) ||
-      (!Number.isFinite(totalPages) && records.length < pageSize);
-
-    prevButton.disabled = disablePrev;
-    nextButton.disabled = disableNext;
-
-  } catch (error) {
-    if (error.name === "AbortError") {
-      return;
-    }
-
-    console.error(error);
-    renderNoData("No se pudieron obtener los datos de la API.");
-    setStatus(
-      "Ocurrió un error al consultar la API. Verifica tu conexión o intenta nuevamente."
-    );
-    updateSummary({ fetchedCount: 0, filteredCount: 0 });
-  } finally {
-    ongoingFetch = null;
-    setLoading(false);
-  }
-}
-
-function handleSubmit(event) {
-  event.preventDefault();
-  loadRecords(1);
-}
-
-function handleClear() {
   form.reset();
-  pageSize = Number(pageSizeSelect.value) || 50;
-  loadRecords(1);
+
+  window.dispatchEvent(
+    new CustomEvent('procura:form-submitted', {
+      detail: Object.fromEntries(formData.entries()),
+    })
+  );
 }
 
-function handlePageChange(increment) {
-  const nextPage = Math.max(1, currentPage + increment);
-  if (nextPage === currentPage) return;
-  loadRecords(nextPage);
+function init() {
+  updateYear();
+
+  if (navToggle) {
+    navToggle.addEventListener('click', toggleMenu);
+  }
+
+  if (menu) {
+    menu.addEventListener('click', closeMenuOnLinkClick);
+  }
+
+  analyticsElements.forEach((element) => {
+    element.addEventListener('click', trackEvent);
+  });
+
+  if (leadForm) {
+    leadForm.addEventListener('submit', handleFormSubmit);
+  }
 }
 
-form.addEventListener("submit", handleSubmit);
-clearFiltersButton.addEventListener("click", handleClear);
-prevButton.addEventListener("click", () => handlePageChange(-1));
-nextButton.addEventListener("click", () => handlePageChange(1));
-pageSizeSelect.addEventListener("change", () => {
-  pageSize = Number(pageSizeSelect.value) || 50;
-  loadRecords(1);
-});
-
-document.addEventListener("DOMContentLoaded", () => {
-  loadRecords(1);
-});
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,9 +1,18 @@
 :root {
-  color-scheme: light dark;
-  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
-  background-color: #f4f6fb;
-  color: #1f2a44;
-  line-height: 1.5;
+  --color-primary: #1f6feb;
+  --color-accent: #00b894;
+  --color-warm: #ffb020;
+  --color-text: #0b0d17;
+  --color-text-muted: #4a4f62;
+  --color-bg: #f8fafc;
+  --color-card: #ffffff;
+  --color-border: #d5d9e3;
+  --shadow-soft: 0 12px 30px rgba(15, 34, 58, 0.12);
+  --shadow-sm: 0 6px 18px rgba(31, 111, 235, 0.14);
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  font-family: 'Inter', 'DM Sans', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
 }
 
 * {
@@ -12,258 +21,822 @@
 
 body {
   margin: 0;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.site-header,
-.site-footer {
-  background: linear-gradient(120deg, #143d6d, #1060a4);
-  color: #fff;
-  padding: 1.5rem 1rem;
-  text-align: center;
-}
-
-.site-header h1 {
-  margin: 0 0 0.5rem;
-  font-size: clamp(1.8rem, 2.5vw + 1rem, 2.6rem);
-}
-
-.site-header .subtitle {
-  margin: 0 auto;
-  max-width: 56rem;
+  font-family: inherit;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  line-height: 1.6;
   font-size: 1rem;
-  opacity: 0.9;
 }
 
-.site-footer a {
-  color: #fff;
-  font-weight: 600;
+img {
+  max-width: 100%;
+  display: block;
+}
+
+main {
+  overflow: hidden;
 }
 
 .container {
-  width: min(1200px, 95vw);
-  margin: 2rem auto;
-  flex: 1 0 auto;
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
+  width: min(1120px, 94vw);
+  margin: 0 auto;
 }
 
-.card {
-  background-color: #fff;
-  border-radius: 1rem;
-  box-shadow: 0 12px 30px rgba(23, 43, 77, 0.12);
-  padding: 1.5rem;
+.section {
+  padding: 4.5rem 0;
 }
 
-.filters fieldset {
-  border: none;
+.section:nth-of-type(even) {
+  background-color: #eef2fb;
+}
+
+h1,
+ h2,
+ h3 {
+  font-family: 'DM Sans', 'Inter', sans-serif;
+  color: var(--color-text);
+  margin: 0 0 0.75em;
+}
+
+h1 {
+  font-size: clamp(2.25rem, 4vw + 1rem, 3.4rem);
+  line-height: 1.1;
+}
+
+h2 {
+  font-size: clamp(1.75rem, 2.5vw + 1rem, 2.5rem);
+}
+
+h3 {
+  font-size: 1.25rem;
+}
+
+p {
+  margin: 0 0 1em;
+  color: var(--color-text-muted);
+}
+
+ul,
+ol {
+  margin: 0 0 1.5em 1.5em;
   padding: 0;
-  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.hero {
+  padding: 6rem 0 4rem;
+  background: radial-gradient(circle at 10% 20%, rgba(31, 111, 235, 0.1) 0%, transparent 55%),
+    radial-gradient(circle at 90% 10%, rgba(255, 176, 32, 0.18) 0%, transparent 50%),
+    var(--color-card);
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background-color: rgba(248, 250, 252, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(213, 217, 227, 0.7);
+}
+
+.nav-content {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   gap: 1.5rem;
+  padding: 0.75rem 0;
 }
 
-.filters legend {
-  font-size: 1.2rem;
+.brand {
   font-weight: 700;
-  margin-bottom: 0.5rem;
-}
-
-.filters .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 1rem;
-}
-
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
-  font-weight: 600;
-  color: #0f1c2f;
-}
-
-.field input,
-.field select {
-  border-radius: 0.75rem;
-  border: 1px solid #d0d7e2;
-  padding: 0.65rem 0.85rem;
-  font-size: 0.95rem;
-  transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.field input:focus,
-.field select:focus {
-  border-color: #0b74de;
-  box-shadow: 0 0 0 3px rgba(11, 116, 222, 0.2);
-  outline: none;
-}
-
-.actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.actions button {
-  border: none;
-  border-radius: 999px;
-  padding: 0.7rem 1.4rem;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.actions .primary {
-  background: linear-gradient(120deg, #0c77e9, #00a0d6);
-  color: #fff;
-  box-shadow: 0 10px 20px rgba(12, 119, 233, 0.25);
-}
-
-.actions button:not(.primary) {
-  background-color: #eef2f9;
-  color: #0f1c2f;
-}
-
-.actions button:hover {
-  transform: translateY(-1px);
-}
-
-.status-bar {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  font-size: 0.95rem;
-}
-
-.status-text {
-  min-height: 1.2rem;
-}
-
-.pagination .pager {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 1rem;
-}
-
-.pagination button {
-  width: 2.5rem;
-  height: 2.5rem;
-  border-radius: 50%;
-  border: none;
-  background-color: #0c77e9;
-  color: #fff;
-  font-size: 1.2rem;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 8px 18px rgba(12, 119, 233, 0.3);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-}
-
-.pagination button:disabled {
-  opacity: 0.4;
-  cursor: not-allowed;
-  box-shadow: none;
-}
-
-.pagination button:not(:disabled):hover {
-  transform: translateY(-1px);
-}
-
-.page-info {
-  font-weight: 600;
-}
-
-.table-wrapper {
-  overflow-x: auto;
-}
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.95rem;
-}
-
-thead {
-  background-color: #f0f4fb;
-  color: #0f1c2f;
-}
-
-thead th {
-  padding: 0.75rem;
-  text-align: left;
-  font-size: 0.9rem;
-}
-
-tbody tr:nth-child(even) {
-  background-color: rgba(15, 28, 47, 0.03);
-}
-
-th,
-td {
-  padding: 0.85rem;
-  vertical-align: top;
-  border-bottom: 1px solid rgba(15, 28, 47, 0.05);
-}
-
-.title-cell {
-  font-weight: 700;
-  color: #0b3d91;
-}
-
-.title-cell a {
-  color: inherit;
+  font-size: 1.25rem;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
-.title-cell a:hover {
-  text-decoration: underline;
+.nav-links {
+  position: relative;
+  flex: 1;
 }
 
-.meta,
-.unspsc-list {
-  margin: 0.3rem 0 0;
-  font-size: 0.85rem;
-  color: #47536b;
+.nav-links ul {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
-.badge {
-  display: inline-block;
-  padding: 0.2rem 0.55rem;
-  margin: 0.15rem 0.25rem 0.15rem 0;
-  border-radius: 999px;
-  background-color: rgba(12, 119, 233, 0.1);
-  color: #0c77e9;
+.nav-links a {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.nav-links a:hover,
+.nav-links a:focus {
+  color: var(--color-primary);
+}
+
+.nav-ctas {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 14px;
   font-weight: 600;
-  font-size: 0.75rem;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease,
+    border-color 0.2s ease;
+  cursor: pointer;
+  border: 2px solid transparent;
 }
 
-.amount {
+.btn:focus-visible {
+  outline: 3px solid rgba(0, 184, 148, 0.5);
+  outline-offset: 3px;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #1f6feb, #225dd4);
+  color: #fff;
+  box-shadow: var(--shadow-sm);
+}
+
+.btn.primary:hover {
+  transform: translateY(-1px);
+}
+
+.btn.secondary {
+  background-color: #fff;
+  color: var(--color-primary);
+  border-color: rgba(31, 111, 235, 0.35);
+  box-shadow: 0 6px 16px rgba(31, 111, 235, 0.1);
+}
+
+.btn.secondary:hover {
+  background-color: rgba(31, 111, 235, 0.08);
+}
+
+.btn.ghost {
+  background-color: transparent;
+  color: var(--color-text);
+  border-color: rgba(31, 111, 235, 0.2);
+}
+
+.btn.link {
+  padding: 0.25rem 0;
+  border: none;
+  background: none;
+  color: var(--color-primary);
+  box-shadow: none;
+  font-weight: 600;
+}
+
+.btn.link:hover {
+  color: #174cb4;
+}
+
+.hero-grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.hero-bullets {
+  list-style: none;
+  margin: 1.5rem 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.hero-bullets li {
+  background-color: rgba(31, 111, 235, 0.08);
+  border: 1px solid rgba(31, 111, 235, 0.16);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-weight: 500;
+  color: var(--color-primary);
+}
+
+.hero-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.lead {
+  font-size: 1.125rem;
+}
+
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--color-accent);
+  background-color: rgba(0, 184, 148, 0.1);
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  margin-bottom: 1rem;
+}
+
+.social-proof {
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+}
+
+.social-proof .note {
+  display: block;
+  font-size: 0.85rem;
+  color: #6f7485;
+}
+
+.hero-media {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.workflow-illustration {
+  background-color: var(--color-card);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px solid rgba(31, 111, 235, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.workflow-steps {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.workflow-steps .step {
+  flex: 1;
+  min-width: 110px;
+  text-align: center;
+  background: linear-gradient(135deg, rgba(31, 111, 235, 0.85), rgba(0, 184, 148, 0.85));
+  color: #fff;
+  padding: 0.65rem 0.5rem;
+  border-radius: 12px;
+  font-weight: 600;
+}
+
+.mockups {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.mockup {
+  background: #101828;
+  color: #f5f7ff;
+  padding: 2rem 1.5rem;
+  border-radius: var(--radius-md);
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(16, 24, 40, 0.2);
+}
+
+.mockup::before {
+  content: '';
+  position: absolute;
+  top: -40px;
+  right: -40px;
+  width: 120px;
+  height: 120px;
+  background: rgba(255, 176, 32, 0.3);
+  border-radius: 50%;
+  filter: blur(0.5px);
+}
+
+.two-column {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+}
+
+.card.highlight {
+  background-color: var(--color-card);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(31, 111, 235, 0.15);
+}
+
+.card.highlight h3 {
+  margin-top: 0;
+}
+
+.steps-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.step-card {
+  background-color: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  border: 1px solid rgba(31, 111, 235, 0.12);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+}
+
+.step-number {
+  position: absolute;
+  top: -16px;
+  left: 20px;
+  background-color: var(--color-primary);
+  color: #fff;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
   font-weight: 700;
-  color: #0f1c2f;
 }
 
-@media (max-width: 640px) {
-  .actions {
-    flex-direction: column;
-    align-items: stretch;
+.columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.columns h3 {
+  color: var(--color-primary);
+}
+
+.columns ul {
+  list-style: none;
+  padding: 0;
+}
+
+.columns li {
+  padding: 0.35rem 0;
+  border-bottom: 1px dashed rgba(31, 111, 235, 0.2);
+}
+
+.columns li:last-child {
+  border-bottom: none;
+}
+
+.disclaimer {
+  font-size: 0.95rem;
+  color: #5d6373;
+}
+
+.disclaimer.small {
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.feature-card {
+  background-color: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-soft);
+}
+
+.feature-card h3 {
+  color: var(--color-primary);
+}
+
+.technology {
+  background: linear-gradient(145deg, rgba(31, 111, 235, 0.1), rgba(0, 184, 148, 0.12));
+}
+
+.tech-diagram {
+  background-color: rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  border: 1px solid rgba(31, 111, 235, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.diagram-flow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+  gap: 0.75rem;
+  text-align: center;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.diagram-flow span {
+  background-color: rgba(31, 111, 235, 0.08);
+  border-radius: 12px;
+  padding: 0.75rem 0.5rem;
+}
+
+.security {
+  background-color: #0b1f3d;
+  color: #fff;
+}
+
+.security h2,
+.security p,
+.security .disclaimer {
+  color: #fff;
+}
+
+.security-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.security-item {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.integrations {
+  text-align: center;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 2rem 0;
+}
+
+.chip {
+  background-color: rgba(0, 184, 148, 0.12);
+  border: 1px solid rgba(0, 184, 148, 0.3);
+  color: var(--color-text);
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+}
+
+.pricing-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.plan-card {
+  background-color: var(--color-card);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem 2rem;
+  text-align: center;
+  border: 1px solid rgba(31, 111, 235, 0.12);
+  box-shadow: var(--shadow-soft);
+}
+
+.plan-card h3 {
+  font-size: 1.5rem;
+}
+
+.plan-card .tagline {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.plan-card.featured {
+  border: 2px solid var(--color-primary);
+  transform: translateY(-10px);
+}
+
+.testimonial-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.testimonial {
+  background-color: var(--color-card);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-soft);
+  font-style: italic;
+}
+
+.testimonial blockquote {
+  margin: 0 0 1rem;
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.faq-list details {
+  border-radius: var(--radius-md);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 0.75rem;
+  background-color: var(--color-card);
+  border: 1px solid rgba(31, 111, 235, 0.1);
+  box-shadow: var(--shadow-soft);
+}
+
+.faq-list summary {
+  cursor: pointer;
+  font-weight: 600;
+  outline: none;
+}
+
+.faq-list summary:focus-visible {
+  outline: 3px solid rgba(31, 111, 235, 0.4);
+  border-radius: 12px;
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.resource-card {
+  background-color: var(--color-card);
+  border-radius: var(--radius-lg);
+  padding: 2rem;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  box-shadow: var(--shadow-soft);
+}
+
+.lead {
+  background: radial-gradient(circle at 10% 10%, rgba(31, 111, 235, 0.18), transparent 45%),
+    radial-gradient(circle at 90% 20%, rgba(0, 184, 148, 0.25), transparent 55%),
+    #0e1726;
+  color: #fff;
+}
+
+.lead h2,
+.lead p {
+  color: #fff;
+}
+
+.lead-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.cta-buttons {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 1.5rem;
+}
+
+.lead-form {
+  background-color: rgba(255, 255, 255, 0.98);
+  color: var(--color-text);
+  border-radius: var(--radius-lg);
+  padding: 2.5rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(31, 111, 235, 0.12);
+}
+
+.lead-form label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  color: var(--color-text);
+  gap: 0.5rem;
+}
+
+.lead-form input,
+.lead-form select,
+.lead-form textarea {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  font: inherit;
+  background-color: #fff;
+  color: var(--color-text);
+}
+
+.lead-form input:focus-visible,
+.lead-form select:focus-visible,
+.lead-form textarea:focus-visible {
+  outline: 3px solid rgba(31, 111, 235, 0.35);
+  border-color: var(--color-primary);
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-grid .full {
+  grid-column: 1 / -1;
+}
+
+.consent {
+  margin: 1.5rem 0 1rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.consent input {
+  margin-top: 0.2rem;
+}
+
+.form-success {
+  min-height: 1.5rem;
+  margin-top: 1rem;
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+.footer {
+  background-color: #030712;
+  color: #c7c9d3;
+  padding: 3rem 0;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.footer nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.footer nav a,
+.footer-links a {
+  color: #c7c9d3;
+  text-decoration: none;
+}
+
+.footer nav a:hover,
+.footer-links a:hover {
+  color: #fff;
+}
+
+.footer-ctas {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.footer .brand {
+  color: #fff;
+}
+
+.footer-links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.nav-toggle span {
+  width: 24px;
+  height: 2px;
+  background-color: var(--color-text);
+  display: block;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav-links.open ul {
+  display: grid;
+}
+
+@media (max-width: 960px) {
+  .nav-content {
+    flex-wrap: wrap;
   }
 
-  .pagination button {
-    width: 2.2rem;
-    height: 2.2rem;
+  .nav-links {
+    order: 3;
+    width: 100%;
   }
 
-  th,
-  td {
-    padding: 0.7rem 0.5rem;
+  .nav-toggle {
+    display: flex;
+    position: absolute;
+    right: 0;
+    top: -8px;
+  }
+
+  .nav-links ul {
+    display: none;
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    padding: 1rem 0 0;
+  }
+
+  .nav-ctas {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding-top: 7rem;
+  }
+
+  .nav-ctas {
+    justify-content: center;
+  }
+
+  .nav-links ul {
+    text-align: center;
+  }
+
+  .nav-links.open ul {
+    background-color: rgba(255, 255, 255, 0.95);
+    border-radius: 16px;
+    padding: 1rem;
+    box-shadow: var(--shadow-soft);
+  }
+
+  .hero-bullets {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-ctas {
+    width: 100%;
+  }
+
+  .workflow-steps {
+    justify-content: center;
+  }
+
+  .columns {
+    grid-template-columns: 1fr;
+  }
+
+  .cta-buttons,
+  .footer-ctas {
+    justify-content: center;
+  }
+
+  .plan-card.featured {
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
 }


### PR DESCRIPTION
## Summary
- replace the existing OCDS explorer with a single-page Procura marketing site tailored to licitaciones públicas
- add dedicated sections for workflows, automation scope, pricing, FAQs, resources, and a lead capture form with clear CTAs
- restyle the page with the requested color palette, typography, and responsive layout enhancements while wiring analytics-ready CTA hooks

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6909eea0dfe883339ff5ccf5901b8409